### PR TITLE
Bug: Multiple bugfixes for gacha command feature

### DIFF
--- a/musicbot/CommandModifier.py
+++ b/musicbot/CommandModifier.py
@@ -23,13 +23,13 @@ class CommandModifier:
  
     def _initializeAliasesFile(self, aliases_file):
         if aliases_file is None:
-            self._aliases = NoAliases()
+            self._aliases = CommandModifier.NoAliases()
         else:
             self._aliases = Aliases(aliases_file)
             
     def _initializeGachaFile(self, gacha_file):
         if gacha_file is None:
-            self._gacha = NoGacha()
+            self._gacha = CommandModifier.NoGacha()
         else:
             self._gacha = Gacha(gacha_file)
             
@@ -40,15 +40,24 @@ class CommandModifier:
         return self._gacha.roll(command)
         
     def get(self, original_command, original_args):
+        log.debug("get called. original_command: {}, original_args:{}".format(
+            original_command,
+            str(original_args)
+        ))
         modified_command = self.modifyUsingAlias(original_command)
         modified_command, *modified_args = modified_command.split(" ")
+        log.debug("modified_command: {}, modified_args: {}".format(
+            modified_command,
+            str(modified_args)
+        ))
 
         if modified_command == "gacha":
             modified_command = self.modifyUsingGacha(" ".join(modified_args))
             modified_command, *modified_args = modified_command.split(" ")
         elif modified_command == "" and original_command == "gacha":
-            modified_command = self.modifyUsingGacha(" ".join(args))
+            modified_command = self.modifyUsingGacha(" ".join(original_args))
             modified_command, *modified_args = modified_command.split(" ")
+            original_args = []
  
         for modified_arg in modified_args:
             original_args.append(modified_arg)

--- a/musicbot/gacha.py
+++ b/musicbot/gacha.py
@@ -6,8 +6,8 @@ import random
 
 from .exceptions import HelpfulError
 
-log = logging.getLogger(__name__)
 
+log = logging.getLogger(__name__)
 
 class Gacha:
 
@@ -22,11 +22,15 @@ class Gacha:
             self._maximum_value = maximum_value
             
         def isNumberWithinBounds(self, value):
-            return value >= self._minimum_value and value < self._maximum_value
+            return value >= self._minimum_value and value <= self._maximum_value
             
         def getNormalCommand(self):
             return self._normal_command
             
+    class NoneCommand(Command):
+        def __init__(self):
+            super().__init__("", -1, -1)
+
 
     def __init__(self, gacha_file):
         log.debug("__init__ called.")
@@ -91,8 +95,12 @@ class Gacha:
                 log.warning("Unable to parse command: {}. Discarding.".format(str(normal_command)))
             else:
                 parsed_rate = self._parseRate(rate)
-                self._gacha_commands[gacha_command]["normal_commands"].append(Gacha.Command(normal_command, current_maximum_value, current_maximum_value + parsed_rate))
-                current_maximum_value = current_maximum_value + parsed_rate + 1
+                gacha_command_minimum_value = current_maximum_value
+                gacha_command_maximum_value = current_maximum_value + parsed_rate - 1
+                self._gacha_commands[gacha_command]["normal_commands"].append(
+                    Gacha.Command(normal_command, gacha_command_minimum_value, gacha_command_maximum_value)
+                )
+                current_maximum_value = gacha_command_maximum_value + 1
                 
         self._gacha_commands[gacha_command]["maximum_value"] = current_maximum_value
         
@@ -107,7 +115,7 @@ class Gacha:
         
     def _rollNormalCommand(self, gacha_command):
         log.debug("_rollNormalCommand called. gacha_command: {}".format(str(gacha_command)))
-        command = None
+        command = Gacha.NoneCommand()
         gacha = self._gacha_commands[gacha_command]
         rolled_number = random.randint(0, gacha["maximum_value"] - 1)
         log.debug("rolled_number: " + str(rolled_number))
@@ -118,8 +126,7 @@ class Gacha:
         
     def roll(self, gacha_command):
         log.debug("roll called. gacha_command: {}".format(str(gacha_command)))
-        normal_command = None
-        print(gacha_command)
+        normal_command = ""
         if gacha_command in self._gacha_commands:
             normal_command = self._rollNormalCommand(gacha_command)
         log.debug("normal_command: " + str(normal_command))


### PR DESCRIPTION
Fixes for the following issues:
- !gacha command not working when typed from discord chat
- Gacha class not assigning the proper minimum and maximum values
- tiny chance for Gacha class to fail to find any command, which will lead to an app crash
- app crash when Gacha.roll is called on an unspecified command
- app crash when aliases_file and gacha_file is None when passed to CommandModifier