### PR TITLE
Feature: Display rates for gacha commands

### DIFF
--- a/musicbot/CommandModifier.py
+++ b/musicbot/CommandModifier.py
@@ -50,17 +50,17 @@ class CommandModifier:
             modified_command = self.modifyUsingGacha(" ".join(modified_args))
             modified_command, *modified_args = modified_command.split(" ")
         elif modified_command == "" and original_command == "gacha":
-            modified_command = self.modifyUsingGacha(" ".join(original_args))
-            modified_command, *modified_args = modified_command.split(" ")
-            original_args = []
- 
-        for modified_arg in modified_args:
-            original_args.append(modified_arg)
-            
-        if modified_command == "gacha":
-            modified_command = "gacha_internal"
+            if len(original_args) > 0 and original_args[0] == "rates":
+                modified_command = "gacha_internal"
+                modified_args = []
+            else:
+                modified_command = self.modifyUsingGacha(" ".join(original_args))
+                modified_command, *modified_args = modified_command.split(" ")
 
-        return modified_command, original_args
+            for original_arg in original_args:
+                modified_args.append(original_arg)
+
+        return modified_command, modified_args
         
     def rates(self, gacha_command):
         return self._gacha.rates(gacha_command)

--- a/musicbot/CommandModifier.py
+++ b/musicbot/CommandModifier.py
@@ -1,7 +1,7 @@
 import logging
 
 from .aliases import Aliases
-from .gacha import Gacha
+from .gacha import Gacha, NoGacha
 
 
 log = logging.getLogger(__name__)
@@ -10,12 +10,7 @@ class CommandModifier:
 
     class NoAliases:
         def get(self, arg):
-            return ""
-            
-    class NoGacha:
-        def roll(self, arg):
-            return ""
-            
+            return ""      
 
     def __init__(self, aliases_file, gacha_file):
         self._initializeAliasesFile(aliases_file)
@@ -47,11 +42,31 @@ class CommandModifier:
             modified_command = self.modifyUsingGacha(" ".join(modified_args))
             modified_command, *modified_args = modified_command.split(" ")
         elif modified_command == "" and original_command == "gacha":
-            modified_command = self.modifyUsingGacha(" ".join(args))
+            modified_command = self.modifyUsingGacha(" ".join(original_args))
             modified_command, *modified_args = modified_command.split(" ")
+            original_args = []
  
         for modified_arg in modified_args:
             original_args.append(modified_arg)
+            
+        if modified_command == "gacha":
+            modified_command = "gacha_internal"
 
         return modified_command, original_args
+        
+    def rates(self, gacha_command):
+        return self._gacha.rates(gacha_command)
+        
+    def generateDiscordEmbedForRates(self, gacha_command = None):
+        embeds = []
+        if gacha_command is None:
+            commands = self._gacha.commands()
+            for command in commands:
+                embeds.append(self._gacha.generateDiscordEmbedForRates(command))
+        else:
+            embed = self._gacha.generateDiscordEmbedForRates(gacha_command)
+            if embed is not None:
+                embeds.append(embed)
+        return embeds
+
         

--- a/musicbot/block12/bot.py
+++ b/musicbot/block12/bot.py
@@ -4,6 +4,7 @@ from .config import Block12ConfigDecorator
 from musicbot.aliases import AliasesDefault
 from musicbot.bot import MusicBot
 from musicbot.CommandModifier import CommandModifier
+from musicbot.constructs import Response
 from musicbot.gacha import GachaDefault
 
 
@@ -23,6 +24,31 @@ class Block12MusicBot(MusicBot):
         Block12ConfigDecorator(self.config)
         self._initializeCommandModifier(aliases_file, gacha_file)
         
+    async def cmd_gacha_internal(self, channel, leftover_args):
+        log.info("cmd_gacha called. leftover_args: {}".format(
+            str(leftover_args)
+        ))
+        response = None
+        subcommand = None if len(leftover_args) < 1 else leftover_args[0]
+        
+        if subcommand == "rates":
+            gacha_command = None if len(leftover_args) < 2 else leftover_args[1]
+            log.debug("displaying rates. gacha_command: {}".format(str(gacha_command)))
+            
+            embeds = self.command_modifier.generateDiscordEmbedForRates(gacha_command)
+            if len(embeds) <= 0:
+                response = "No rates found{}.".format("" if gacha_command is None else " for " + gacha_command)
+            else:
+                for embed in embeds:
+                    await self.safe_send_message(channel, embed)
+        elif subcommand == None:
+            response = "No arguments provided."
+        else:
+            log.debug("subcommand not recognized: {}".format(subcommand))
+            response = "Invalid arguments provided. args: {}".format(str(leftover_args))
+            
+        return None if response is None else Response(response)
+        
     def _initializeCommandModifier(self, aliases_file, gacha_file):
         aliases_file = aliases_file if aliases_file is not None else AliasesDefault.aliases_file
         gacha_file = gacha_file if gacha_file is not None else GachaDefault.gacha_file
@@ -30,3 +56,5 @@ class Block12MusicBot(MusicBot):
             aliases_file if self.config.usealias else None,
             gacha_file if self.config.usegacha else None)
         self.should_command_modifier_be_used = self.config.usealias or self.config.usegacha
+        
+    

--- a/musicbot/block12/bot.py
+++ b/musicbot/block12/bot.py
@@ -35,12 +35,15 @@ class Block12MusicBot(MusicBot):
             gacha_command = None if len(leftover_args) < 2 else leftover_args[1]
             log.debug("displaying rates. gacha_command: {}".format(str(gacha_command)))
             
-            embeds = self.command_modifier.generateDiscordEmbedForRates(gacha_command)
-            if len(embeds) <= 0:
-                response = "No rates found{}.".format("" if gacha_command is None else " for " + gacha_command)
+            if self.config.embeds:
+                embeds = self.command_modifier.generateDiscordEmbedForRates(gacha_command)
+                if len(embeds) <= 0:
+                    response = "No rates found{}.".format("" if gacha_command is None else " for " + gacha_command)
+                else:
+                    for embed in embeds:
+                        await self.safe_send_message(channel, embed)
             else:
-                for embed in embeds:
-                    await self.safe_send_message(channel, embed)
+                response = "Embeds are disabled. Unable to display gacha rates."
         elif subcommand == None:
             response = "No arguments provided."
         else:

--- a/musicbot/gacha.py
+++ b/musicbot/gacha.py
@@ -137,15 +137,15 @@ class Gacha:
         log.debug("normal_command: " + str(normal_command))
         return normal_command
         
-    def rates(self, gacha_command):
-        log.debug("rates called. gacha_command: {}".format(str(gacha_command)))
-        rates = None
+    def weights(self, gacha_command):
+        log.debug("weights called. gacha_command: {}".format(str(gacha_command)))
+        weights = None
         if gacha_command in self._gacha_commands:
-            rates = self._gacha_commands[gacha_command]
-            log.debug("rates found for given command. rates: {}".format(str(rates)))
+            weights = self._gacha_commands[gacha_command]
+            log.debug("weights found for given command. weights: {}".format(str(weights)))
         else:
-            log.debug("no rates found for given command. gacha_commands: {}".format(str(self._gacha_commands)))
-        return rates
+            log.debug("no weights found for given command. gacha_commands: {}".format(str(self._gacha_commands)))
+        return weights
         
     def commands(self):
         keys = self._gacha_commands.keys()
@@ -155,19 +155,19 @@ class Gacha:
     def generateDiscordEmbedForRates(self, gacha_command):
         log.debug("generateDiscordEmbedForRates called. gacha_command: {}".format(gacha_command))
         embed = None
-        rates = self.rates(gacha_command)
+        weights = self.weights(gacha_command)
         
-        if rates is not None:
+        if weights is not None:
             embed = discord.Embed()
             embed.title = "Gacha Rate: {}".format(gacha_command)
             
-            maximum_value = rates["maximum_value"]
+            maximum_value = weights["maximum_value"]
             
             commands_string = ""
             weights_string = ""
             rates_string = ""
             
-            for command in rates["normal_commands"]:
+            for command in weights["normal_commands"]:
                 weight = command.getWeight()
                 commands_string += '\n' + command.getNormalCommand()
                 weights_string += '\n' + str(weight)
@@ -193,7 +193,7 @@ class NoGacha(Gacha):
     def roll(self, arg):
         return ""
         
-    def rates(self, arg):
+    def weights(self, arg):
         return None
         
     def commands(self):

--- a/musicbot/gacha.py
+++ b/musicbot/gacha.py
@@ -1,3 +1,4 @@
+import discord
 import json
 import logging
 import shutil
@@ -12,20 +13,26 @@ log = logging.getLogger(__name__)
 class Gacha:
 
     class Command:
-        def __init__(self, normal_command, minimum_value, maximum_value):
-            log.debug("Creating command. normal_command: {}, minimum_value: {}, maximum_value: {}".format(
+        def __init__(self, normal_command, minimum_value, maximum_value, weight):
+            log.debug("Creating command. normal_command: {}, minimum_value: {}, maximum_value: {}, weight: {}".format(
                 str(normal_command), 
                 str(minimum_value), 
-                str(maximum_value)))
+                str(maximum_value),
+                str(weight)
+            ))
             self._normal_command = normal_command
             self._minimum_value = minimum_value
             self._maximum_value = maximum_value
+            self._weight = weight
             
         def isNumberWithinBounds(self, value):
             return value >= self._minimum_value and value < self._maximum_value
             
         def getNormalCommand(self):
             return self._normal_command
+            
+        def getWeight(self):
+            return self._weight
             
 
     def __init__(self, gacha_file):
@@ -85,25 +92,29 @@ class Gacha:
         }
         current_maximum_value = 0
         
-        for normal_command, rate in dictionary.items():
-            log.debug("normal_command: {}, rate: {}".format(str(normal_command), str(rate)))
+        for normal_command, weight in dictionary.items():
+            log.debug("normal_command: {}, weight: {}".format(str(normal_command), str(weight)))
             if not isinstance(normal_command, str):
                 log.warning("Unable to parse command: {}. Discarding.".format(str(normal_command)))
             else:
-                parsed_rate = self._parseRate(rate)
-                self._gacha_commands[gacha_command]["normal_commands"].append(Gacha.Command(normal_command, current_maximum_value, current_maximum_value + parsed_rate))
-                current_maximum_value = current_maximum_value + parsed_rate + 1
+                parsed_weight = self._parseWeight(weight)
+                self._gacha_commands[gacha_command]["normal_commands"].append(Gacha.Command(
+                    normal_command, 
+                    current_maximum_value, 
+                    current_maximum_value + parsed_weight,
+                    parsed_weight))
+                current_maximum_value = current_maximum_value + parsed_weight
                 
         self._gacha_commands[gacha_command]["maximum_value"] = current_maximum_value
         
-    def _parseRate(self, rate):
-        log.debug("_parseRate called")
-        parsed_rate = 0
+    def _parseWeight(self, weight):
+        log.debug("_parseWeight called")
+        parsed_weight = 0
         try:
-            parsed_rate = int(rate)
+            parsed_weight = int(weight)
         except ValueError:
-            log.warning("Unable to parse rate: {}. Setting to 0.".format(str(rate)))
-        return parsed_rate
+            log.warning("Unable to parse weight: {}. Setting to 0.".format(str(weight)))
+        return parsed_weight
         
     def _rollNormalCommand(self, gacha_command):
         log.debug("_rollNormalCommand called. gacha_command: {}".format(str(gacha_command)))
@@ -124,6 +135,49 @@ class Gacha:
             normal_command = self._rollNormalCommand(gacha_command)
         log.debug("normal_command: " + str(normal_command))
         return normal_command
+        
+    def rates(self, gacha_command):
+        log.debug("rates called. gacha_command: {}".format(str(gacha_command)))
+        rates = None
+        if gacha_command in self._gacha_commands:
+            rates = self._gacha_commands[gacha_command]
+            log.debug("rates found for given command. rates: {}".format(str(rates)))
+        else:
+            log.debug("no rates found for given command. gacha_commands: {}".format(str(self._gacha_commands)))
+        return rates
+        
+    def commands(self):
+        keys = self._gacha_commands.keys()
+        log.debug("commands called. keys: {}".format(str(keys)))
+        return keys
+        
+    def generateDiscordEmbedForRates(self, gacha_command):
+        log.debug("generateDiscordEmbedForRates called. gacha_command: {}".format(gacha_command))
+        embed = None
+        rates = self.rates(gacha_command)
+        
+        if rates is not None:
+            embed = discord.Embed()
+            embed.title = "Gacha Rate: {}".format(gacha_command)
+            
+            maximum_value = rates["maximum_value"]
+            
+            commands_string = ""
+            weights_string = ""
+            rates_string = ""
+            
+            for command in rates["normal_commands"]:
+                weight = command.getWeight()
+                commands_string += '\n' + command.getNormalCommand()
+                weights_string += '\n' + str(weight)
+                rates_string += '\n' + str(round(weight / maximum_value, 4) * 100) + "%"
+            
+            embed.add_field(name = "Command", value = commands_string, inline = True)
+            embed.add_field(name = "Weight", value = weights_string, inline = True)
+            embed.add_field(name = "Rate", value = rates_string, inline = True)
+            embed.add_field(name = "Maximum Value", value = maximum_value, inline = False)
+        
+        return embed
                 
 
 class GachaDefault:
@@ -131,3 +185,17 @@ class GachaDefault:
     gacha_file = "config/gacha.json"
     gacha_seed = {}
     gacha = {}
+
+
+class NoGacha(Gacha):
+    def roll(self, arg):
+        return ""
+        
+    def rates(self, arg):
+        return None
+        
+    def commands(self):
+        return []
+        
+    def generateDiscordEmbedForRates(self, arg):
+        return None

--- a/musicbot/gacha.py
+++ b/musicbot/gacha.py
@@ -36,7 +36,7 @@ class Gacha:
 
     class NoneCommand(Command):
         def __init__(self):
-            super().__init__("", -1, -1)
+            super().__init__("", -1, -1, -1)
 
 
     def __init__(self, gacha_file):
@@ -173,12 +173,12 @@ class Gacha:
                 weight = command.getWeight()
                 commands_string += '\n' + command.getNormalCommand()
                 weights_string += '\n' + str(weight)
-                rates_string += '\n' + str(round(weight / maximum_value, 4) * 100) + "%"
+                rates_string += "\n{0:.2f}%".format(round(weight / maximum_value, 4) * 100)
             
             embed.add_field(name = "Command", value = commands_string, inline = True)
             embed.add_field(name = "Weight", value = weights_string, inline = True)
             embed.add_field(name = "Rate", value = rates_string, inline = True)
-            embed.add_field(name = "Maximum Value", value = maximum_value, inline = False)
+            embed.add_field(name = "Maximum Weight", value = maximum_value, inline = False)
         
         return embed
                 


### PR DESCRIPTION
**Description:**
- Bot can now display rates for gacha commands via command !gacha rate [command]
- Displays the following info: command, weight, rate and maximum weight

**Extras:**
- Improved gacha rolling algorithm by checking if rolled number is under a command's ceiling value instead of checking if it is within a min and max value
- Renamed "rate" to "weight" where it applies
- NoneCommand will no longer be created repeatedly when rolling for a command
- In CommandModifier, "modified_args" will now be prioritized over "original_args" 