### PR TITLE
Bugfix: Bot stops working after reconnecting and !play is triggered

### DIFF
--- a/musicbot/block12/bot.py
+++ b/musicbot/block12/bot.py
@@ -2,6 +2,7 @@ import logging
 
 from .config import Block12ConfigDecorator
 from .permissions import Block12PermissionsDecorator
+from .player import Block12MusicPlayerInjector
 
 from musicbot.aliases import AliasesDefault
 from musicbot.billboard.Manager import Manager as BillboardManager
@@ -28,6 +29,12 @@ class Block12MusicBot(MusicBot):
         Block12PermissionsDecorator(self.permissions)
         self._initializeCommandModifier(aliases_file, gacha_file)
 
+    async def on_connect(self):
+        log.info("\nMusicBot connected.")
+
+    async def on_disconnect(self):
+        log.info("MusicBot disconnected.")
+        
     @overrides(MusicBot)
     async def on_ready(self):
         await super().on_ready()
@@ -67,9 +74,10 @@ class Block12MusicBot(MusicBot):
         
     @overrides(MusicBot)
     def _init_player(self, player, *args, guild = None):
-        super()._init_player(player, *args, guild = guild)
-        BillboardManager.addEventEmitter(player)
-        return player
+        Block12MusicPlayerInjector(player)
+        player_to_return = super()._init_player(player, *args, guild = guild)
+        BillboardManager.addEventEmitter(player_to_return)
+        return player_to_return
 
     def _initializeCommandModifier(self, aliases_file, gacha_file):
         aliases_file = aliases_file if aliases_file is not None else AliasesDefault.aliases_file

--- a/musicbot/block12/player.py
+++ b/musicbot/block12/player.py
@@ -5,12 +5,6 @@ import types
 
 log = logging.getLogger(__name__)
 
-def overrides(interface_class):
-    def overrider(method):
-        assert(method.__name__ in dir(interface_class))
-        return method
-    return overrider
-
 
 class Block12MusicPlayerInjector:
 
@@ -30,3 +24,4 @@ class Block12MusicPlayerInjector:
                 "entries": self.playlist,
             }
         )
+

--- a/musicbot/block12/player.py
+++ b/musicbot/block12/player.py
@@ -1,0 +1,32 @@
+from musicbot.player import MusicPlayer
+import logging
+import types
+
+
+log = logging.getLogger(__name__)
+
+def overrides(interface_class):
+    def overrider(method):
+        assert(method.__name__ in dir(interface_class))
+        return method
+    return overrider
+
+
+class Block12MusicPlayerInjector:
+
+    def __init__(self, music_player):
+        log.debug("Using Block12 Music Player")
+        
+        log.debug("Injecting __json__ method.")
+        music_player.__json__ = types.MethodType(Block12MusicPlayerInjector.__json__, music_player)
+
+    def __json__(self):
+        return self._enclose_json(
+            {
+                "current_entry": {
+                    "entry": self.current_entry,
+                    "progress": self.progress,
+                },
+                "entries": self.playlist,
+            }
+        )


### PR DESCRIPTION
**Problem:**
Implementation of \_\_json\_\_ in MusicPlayer requires the value `self._current_player._player.loops` for `progress_frames.` This causes a crash when the bot reconnects after an internet issue because `self._current_player._player` results to None.

**Solution:**
Created injector for MusicPlayer that changes the implementation of its __json__, which removes the `progress_frames` field from the json. The field is not needed anywhere in code and the scope of `_player` in `self._current_player._player.loops` seems to be only within its class

